### PR TITLE
Aggiunge guida e script per continuità di lavoro Mac ⇄ remoto

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -46,6 +46,31 @@ Oppure usa lo script pronto:
 2. **Stesso nome di branch** per lo stesso lavoro, su entrambi i dispositivi.
 3. **`git pull` prima di iniziare** — parti sempre dall'ultimo stato.
 
+## Autosync su Mac (ogni 6 minuti + alla chiusura)
+
+### Periodico ogni 6 minuti
+Installazione una tantum (usa launchd, nativo di macOS):
+```bash
+./scripts/install-mac-autosync.sh
+```
+Da quel momento il lavoro viene committato e pushato da solo ogni 6 minuti
+(e una volta anche al login). Per disattivarlo:
+```bash
+./scripts/install-mac-autosync.sh uninstall
+```
+
+### Push finale quando chiudi la sessione del terminale
+Aggiungi questa riga al tuo `~/.zshrc` (sostituisci il percorso del repo):
+```bash
+trap '"$HOME/percorso/skills-introduction-to-github/scripts/sync.sh" "sync chiusura sessione" >/dev/null 2>&1' EXIT
+```
+Così, ogni volta che chiudi quella finestra/tab del terminale, parte un
+ultimo `sync.sh` che salva tutto.
+
+> **Auth in background:** perché il push automatico funzioni senza chiedere
+> password, fai almeno un push manuale (HTTPS → il token resta nel keychain),
+> oppure usa una chiave SSH senza passphrase / caricata nel keychain.
+
 ## Branch di lavoro attuali
 
 | Branch | Contenuto |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,61 @@
+# Workflow Mac ⇄ Remoto
+
+Guida rapida per lavorare sullo **stesso progetto** sia dal **Mac** sia da **Claude Code remoto** (web) senza perdere lavoro.
+
+## Il principio
+
+Due cose sono separate, e **solo una si sincronizza**:
+
+| Cosa | Si sincronizza Mac ⇄ remoto? |
+|------|------------------------------|
+| La conversazione/chat di Claude Code | ❌ No — vive sul singolo dispositivo |
+| Il lavoro sul codice (file, commit) | ✅ Sì — tramite **git + GitHub** |
+
+> La chat non si sposta da un dispositivo all'altro: non serve. Ciò che conta è il **codice**, e quello viaggia su GitHub attraverso i **branch**.
+
+## Regola d'oro
+
+**Un branch = un filo di lavoro.** Committi e pushi da una parte, fai pull dall'altra.
+
+⚠️ L'unica cosa che puoi perdere è il lavoro **non pushato**. Quindi: commit + push spesso, soprattutto prima che il Mac vada in *sleep* o prima di chiudere una sessione remota.
+
+## Riprendere un lavoro
+
+### Per RIPRENDERE (inizio sessione, su Mac o remoto)
+```bash
+git fetch origin
+git checkout <nome-branch>
+git pull origin <nome-branch>
+```
+
+### Per SALVARE (fine sessione, su Mac o remoto)
+```bash
+git add -A
+git commit -m "wip: dove sono arrivato"
+git push -u origin <nome-branch>
+```
+
+Oppure usa lo script pronto:
+```bash
+./scripts/sync.sh "messaggio del commit"
+```
+
+## Le 3 regole anti-perdita
+
+1. **Committa e pusha spesso** — ciò che non è pushato è l'unica cosa a rischio.
+2. **Stesso nome di branch** per lo stesso lavoro, su entrambi i dispositivi.
+3. **`git pull` prima di iniziare** — parti sempre dall'ultimo stato.
+
+## Branch di lavoro attuali
+
+| Branch | Contenuto |
+|--------|-----------|
+| `main` | Corso completato |
+| `claude/webinar-transcription-course-app-x03f32` | Pipeline video → documento (PR #3) |
+| `claude/content-analysis-summary-ltk090` | Analisi/summary contenuti |
+
+Per riprendere uno di questi sul Mac, dalla cartella del repo:
+```bash
+git fetch origin
+git checkout claude/webinar-transcription-course-app-x03f32
+```

--- a/scripts/install-mac-autosync.sh
+++ b/scripts/install-mac-autosync.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# install-mac-autosync.sh — installa su macOS un autosync del repo ogni 6 minuti.
+#
+# Cosa fa:
+#   - crea un LaunchAgent launchd che esegue scripts/sync.sh ogni 360s (6 min)
+#   - esegue un sync anche al login (RunAtLoad)
+#   - scrive i log in ~/Library/Logs/repo-autosync.*.log
+#
+# Uso:
+#   ./scripts/install-mac-autosync.sh           # installa e avvia
+#   ./scripts/install-mac-autosync.sh uninstall # rimuove l'autosync
+#
+# Nota auth: il push in background usa le credenziali git già salvate.
+#   - HTTPS: assicurati di aver fatto almeno un push manuale così il
+#     credential helper (osxkeychain) memorizza il token.
+#   - SSH: usa una chiave SENZA passphrase, oppure caricata nel keychain
+#     (ssh-add --apple-use-keychain ~/.ssh/id_ed25519).
+
+set -euo pipefail
+
+LABEL="com.anatulia.repo-autosync"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+INTERVAL=360  # 6 minuti
+
+if [ "${1:-}" = "uninstall" ]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "🧹 Autosync rimosso."
+  exit 0
+fi
+
+# Percorso assoluto del repo (radice git a partire da questo script).
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)"
+SYNC="$REPO/scripts/sync.sh"
+
+if [ ! -f "$SYNC" ]; then
+  echo "❌ Non trovo $SYNC — esegui lo script dall'interno del repo."
+  exit 1
+fi
+chmod +x "$SYNC"
+
+mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
+
+cat > "$PLIST" <<PLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$SYNC</string>
+        <string>autosync (launchd)</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$REPO</string>
+    <key>StartInterval</key>
+    <integer>$INTERVAL</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>$HOME/Library/Logs/repo-autosync.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>$HOME/Library/Logs/repo-autosync.err.log</string>
+</dict>
+</plist>
+PLISTEOF
+
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+
+echo "✅ Autosync installato: sync ogni $((INTERVAL/60)) minuti sul repo:"
+echo "   $REPO"
+echo "   Log: ~/Library/Logs/repo-autosync.out.log"
+echo "   Per rimuoverlo: ./scripts/install-mac-autosync.sh uninstall"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -21,14 +21,23 @@ if [ "$branch" = "HEAD" ]; then
   exit 1
 fi
 
-# Niente da fare se il working tree è pulito.
-if git diff --quiet && git diff --cached --quiet && [ -z "$(git status --porcelain)" ]; then
-  echo "✅ Niente da committare: working tree pulito sul branch '$branch'."
-else
+# Ci sono modifiche da committare?
+if [ -n "$(git status --porcelain)" ]; then
   msg="${1:-wip: sync automatico $(date '+%Y-%m-%d %H:%M:%S')}"
   git add -A
   git commit -m "$msg"
   echo "📝 Commit creato: $msg"
+else
+  # Working tree pulito: ci sono commit locali non ancora pushati?
+  if upstream="$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)"; then
+    unpushed="$(git rev-list --count "$upstream"..HEAD)"
+    if [ "$unpushed" -eq 0 ]; then
+      echo "✅ Niente da fare: nessuna modifica e nulla da pushare sul branch '$branch'."
+      exit 0
+    fi
+    echo "ℹ️  Working tree pulito ma ci sono $unpushed commit da pushare."
+  fi
+  # (Se non c'è ancora un upstream, proseguo per crearlo con il push.)
 fi
 
 # Push con un retry semplice in caso di problemi di rete temporanei.

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# sync.sh — salva il lavoro in corso (commit + push) sul branch attuale.
+#
+# Uso:
+#   ./scripts/sync.sh ["messaggio del commit"]
+#
+# Se non passi un messaggio, ne viene generato uno con data/ora.
+# Pensato per essere lanciato prima di chiudere o prima che il Mac vada in sleep,
+# così non perdi mai lavoro non pushato.
+
+set -euo pipefail
+
+# Vai alla radice del repository, qualunque sia la cartella di partenza.
+cd "$(git rev-parse --show-toplevel)"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "HEAD" ]; then
+  echo "❌ Sei in stato 'detached HEAD' (nessun branch). Fai prima 'git checkout <branch>'."
+  exit 1
+fi
+
+# Niente da fare se il working tree è pulito.
+if git diff --quiet && git diff --cached --quiet && [ -z "$(git status --porcelain)" ]; then
+  echo "✅ Niente da committare: working tree pulito sul branch '$branch'."
+else
+  msg="${1:-wip: sync automatico $(date '+%Y-%m-%d %H:%M:%S')}"
+  git add -A
+  git commit -m "$msg"
+  echo "📝 Commit creato: $msg"
+fi
+
+# Push con un retry semplice in caso di problemi di rete temporanei.
+for attempt in 1 2 3; do
+  if git push -u origin "$branch"; then
+    echo "🚀 Push completato sul branch '$branch'."
+    exit 0
+  fi
+  echo "⚠️  Push fallito (tentativo $attempt). Riprovo tra ${attempt}s..."
+  sleep "$attempt"
+done
+
+echo "❌ Push fallito dopo più tentativi. Controlla la connessione e riprova."
+exit 1


### PR DESCRIPTION
## Obiettivo

Permettere di lavorare sullo stesso progetto sia dal **Mac** sia da **Claude Code remoto** senza perdere lavoro, usando git/GitHub come stato condiviso.

## Modifiche

- **`WORKFLOW.md`** — guida ai comandi git per riprendere/salvare il lavoro da Mac e da remoto sullo stesso branch, con le 3 regole anti-perdita.
- **`scripts/sync.sh`** — helper eseguibile che fa commit + push del lavoro in corso (messaggio automatico con data/ora se non specificato, retry sul push). Da lanciare prima di chiudere o prima che il Mac vada in sleep.

## Come si usa

```bash
# riprendere
git fetch origin && git checkout <branch> && git pull origin <branch>

# salvare
./scripts/sync.sh "messaggio"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW3SASEiG6DnUpB3818w1C)_